### PR TITLE
Changing a typo in multipleCB example which resulted in 6 nnz in jaco…

### DIFF
--- a/examples/multipleCB.jl
+++ b/examples/multipleCB.jl
@@ -179,7 +179,7 @@ KNITRO.KN_set_cb_grad(kc, cbC0, callbackEvalC0Grad, jacIndexCons=[indexCons],
 # Set callback data for nonlinear constraint 1 term
 cbC1 = KNITRO.KN_add_eval_callback(kc, false, [cIndices[2]], callbackEvalC1)
 indexCons = [cIndices[2], cIndices[2]]  # constraint c1
-indexVars = [xIndices[1], xIndices[3]]  # variables x0 and x3
+indexVars = [xIndices[1], xIndices[4]]  # variables x0 and x3
 KNITRO.KN_set_cb_grad(kc, cbC1, nothing, jacIndexCons=indexCons, jacIndexVars=indexVars)
 # This one will be approximated via forward finite differences.
 KNITRO.KN_set_cb_gradopt(kc, cbC1, KNITRO.KN_GRADOPT_FORWARD)
@@ -224,6 +224,6 @@ KNITRO.KN_free(kc)
 
 @testset "Example multipleCB" begin
     @test nStatus == 0
-    @test_broken objSol ≈ 0.25
-    @test_broken x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-5
+    @test objSol ≈ 0.25
+    @test x ≈ [0.793701, 0.707107, 0.529732, 0.840896] atol=1e-5
 end


### PR DESCRIPTION
Corrected the NNZ pattern of C1 constraint's first derivative.
Also changed @test_broken to @test.