### PR TITLE
Free knitro in tests and split lic man tests

### DIFF
--- a/examples/nlp1.jl
+++ b/examples/nlp1.jl
@@ -192,7 +192,7 @@ function example_nlp1()
     println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 
     # Delete the Knitro solver instance.
-    #= KNITRO.KN_free(kc) =#
+    KNITRO.KN_free(kc)
 
     @testset "Example HS15 nlp1" begin
         @test nStatus == 0

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -139,3 +139,5 @@ MOI.empty!(CONIC_BRIDGED)
     @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [√2] atol=atol rtol=rtol
     @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [√2, 1.0, -1.0] atol=atol rtol=rtol
 end
+
+KNITRO.free(CONIC_OPTIMIZER)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -25,15 +25,14 @@ const config_noduals = MOIT.TestConfig(atol=1e-5, rtol=1e-8,
     @testset "SolverName" begin
         optimizer = KNITRO.Optimizer()
         @test MOI.get(optimizer, MOI.SolverName()) == "Knitro"
-        MOI.empty!(optimizer)
-        KNITRO.KN_free(optimizer.inner)
+        KNITRO.free(optimizer)
     end
     @testset "supports_default_copy_to" begin
         optimizer = KNITRO.Optimizer()
         @test MOIU.supports_default_copy_to(optimizer, false)
         # Use `@test !...` if names are not supported
         @test MOIU.supports_default_copy_to(optimizer, true)
-        KNITRO.KN_free(optimizer.inner)
+        KNITRO.free(optimizer)
     end
     @testset "MOI.Silent" begin
         optimizer = KNITRO.Optimizer()
@@ -41,7 +40,7 @@ const config_noduals = MOIT.TestConfig(atol=1e-5, rtol=1e-8,
         @test MOI.get(optimizer, MOI.Silent()) == false
         MOI.set(optimizer, MOI.Silent(), true)
         @test MOI.get(optimizer, MOI.Silent()) == true
-        KNITRO.KN_free(optimizer.inner)
+        KNITRO.free(optimizer)
     end
     @testset "MOI.TimeLimitSec" begin
         optimizer = KNITRO.Optimizer()
@@ -51,7 +50,7 @@ const config_noduals = MOIT.TestConfig(atol=1e-5, rtol=1e-8,
         my_time_limit = 10.
         MOI.set(optimizer, MOI.TimeLimitSec(), my_time_limit)
         @test MOI.get(optimizer, MOI.TimeLimitSec()) == my_time_limit
-        KNITRO.KN_free(optimizer.inner)
+        KNITRO.free(optimizer)
     end
     @testset "MOI.RawAttribute" begin
         # Test special RawAttributes
@@ -60,7 +59,7 @@ const config_noduals = MOIT.TestConfig(atol=1e-5, rtol=1e-8,
         MOI.set(optimizer, MOI.RawParameter("option_file"), option_file)
         tuner_file = joinpath(dirname(pathof(KNITRO)),"..", "examples", "tuner-fixed.opt")
         MOI.set(optimizer, MOI.RawParameter("tuner_file"), tuner_file)
-        KNITRO.KN_free(optimizer.inner)
+        KNITRO.free(optimizer)
     end
 end
 
@@ -125,4 +124,4 @@ end
     MOIT.knapsacktest(OPTIMIZER, config)
 end
 
-KNITRO.KN_free(OPTIMIZER.inner)
+KNITRO.free(OPTIMIZER)

--- a/test/jump_soc.jl
+++ b/test/jump_soc.jl
@@ -29,6 +29,7 @@ using JuMP
 
         @test JuMP.value.([x, y, t]) ≈ [0.5, 0.5, sqrt(1/2)] atol=1e-3
 
+        set_optimizer_attribute(m, "free", nothing)
     end
 
     @testset "RotatedSOC1" begin
@@ -53,5 +54,7 @@ using JuMP
         @test JuMP.value.(x) ≈ [1,0,0,0,0] atol=1e-2
         @test JuMP.value(u) ≈ 5.0 atol=1e-4
         @test JuMP.value(v) ≈ sqrt(5.0) atol=1e-4
+
+        set_optimizer_attribute(m, "free", nothing)
     end
 end

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -48,24 +48,6 @@ ENDATA
         KNITRO.KN_free(m)
         @test m.env.ptr_env == C_NULL
     end
-
-    @testset "License manager test" begin
-        # create license manager context
-        lm = KNITRO.LMcontext()
-
-        # we create 10 KNITRO instances with the license manager
-        n_instances = 10
-        kcs = [KNITRO.KN_new_lm(lm) for i in 1:n_instances]
-
-        # then we free the instances
-        for kc in kcs
-            KNITRO.KN_free(kc)
-        end
-
-        # and release the license
-        KNITRO.KN_release_license(lm)
-        @test lm.ptr_lmcontext == C_NULL
-    end
 end
 
 
@@ -686,39 +668,6 @@ end
     @test KNITRO.KN_get_number_iters(kc) == 2
 
     KNITRO.KN_free(kc)
-end
-
-@testset "User params in newpoint callback with license manager (issue #151)" begin
-    function callbackNewPoint(kc, x, duals, userParams)
-        # Test that inputs are of valid type.
-        @test isa(kc, KNITRO.Model)
-        @test isa(x, Vector{Cdouble})
-        @test isa(duals, Vector{Cdouble})
-        return 0
-    end
-    # Instantiate license manager context.
-    lm = KNITRO.LMcontext()
-    # Test different values for userparams: nothing is the default value
-    # so allows to test default Knitro behavior. "myuserparam" tries
-    # setting a string userparam in Knitro.
-    for userparam in [nothing, "myuserparam"]
-        kc = KNITRO.KN_new_lm(lm)
-        KNITRO.KN_set_param(kc, "outlev", 0)
-        # At first, `newpoint_user` is nothing
-        @test isnothing(kc.newpoint_user)
-        KNITRO.KN_add_vars(kc, 1)
-        KNITRO.KN_set_var_lobnds(kc, Cint(0), 2.0)
-        KNITRO.KN_set_var_primal_init_values(kc, [0.0])
-        KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MINIMIZE)
-        KNITRO.KN_add_obj_quadratic_struct(kc, Cint[0], Cint[0], [1.0])
-        KNITRO.KN_set_newpt_callback(kc, callbackNewPoint, userparam)
-        # Test that userparam is correctly set
-        @test kc.newpoint_user == userparam
-        nstatus = KNITRO.KN_solve(kc)
-        @test nstatus == KNITRO.KN_RC_OPTIMAL
-        KNITRO.KN_free(kc)
-    end
-    KNITRO.KN_release_license(lm)
 end
 
 @testset "Handling exception in callbacks" begin

--- a/test/knitroapi_licman.jl
+++ b/test/knitroapi_licman.jl
@@ -1,0 +1,56 @@
+
+using KNITRO
+using Test
+
+@testset "License manager test" begin
+    m = KNITRO.Model()
+    KNITRO.KN_free(m)
+    # create license manager context
+    @show lm = KNITRO.LMcontext()
+
+    # we create 10 KNITRO instances with the license manager
+    n_instances = 10
+    kcs = [KNITRO.KN_new_lm(lm) for i in 1:n_instances]
+
+    # then we free the instances
+    for kc in kcs
+        KNITRO.KN_free(kc)
+    end
+
+    # and release the license
+    KNITRO.KN_release_license(lm)
+    @test lm.ptr_lmcontext == C_NULL
+end
+
+@testset "User params in newpoint callback with license manager (issue #151)" begin
+    function callbackNewPoint(kc, x, duals, userParams)
+        # Test that inputs are of valid type.
+        @test isa(kc, KNITRO.Model)
+        @test isa(x, Vector{Cdouble})
+        @test isa(duals, Vector{Cdouble})
+        return 0
+    end
+    # Instantiate license manager context.
+    lm = KNITRO.LMcontext()
+    # Test different values for userparams: nothing is the default value
+    # so allows to test default Knitro behavior. "myuserparam" tries
+    # setting a string userparam in Knitro.
+    for userparam in [nothing, "myuserparam"]
+        kc = KNITRO.KN_new_lm(lm)
+        KNITRO.KN_set_param(kc, "outlev", 0)
+        # At first, `newpoint_user` is nothing
+        @test isnothing(kc.newpoint_user)
+        KNITRO.KN_add_vars(kc, 1)
+        KNITRO.KN_set_var_lobnds(kc, Cint(0), 2.0)
+        KNITRO.KN_set_var_primal_init_values(kc, [0.0])
+        KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MINIMIZE)
+        KNITRO.KN_add_obj_quadratic_struct(kc, Cint[0], Cint[0], [1.0])
+        KNITRO.KN_set_newpt_callback(kc, callbackNewPoint, userparam)
+        # Test that userparam is correctly set
+        @test kc.newpoint_user == userparam
+        nstatus = KNITRO.KN_solve(kc)
+        @test nstatus == KNITRO.KN_RC_OPTIMAL
+        KNITRO.KN_free(kc)
+    end
+    KNITRO.KN_release_license(lm)
+end

--- a/test/oldexamples.jl
+++ b/test/oldexamples.jl
@@ -1,6 +1,7 @@
 for test_file in readdir(joinpath(dirname(@__FILE__), "..", "examples/oldinterface"))
     # Do not test JuMP examples to avoid conflict between JuMP 0.18 and 0.19.
     if test_file[end-2:end] == ".jl" && !startswith(test_file, "jump")
+        println("Running $test_file")
         include(joinpath(dirname(@__FILE__), "..", "examples/oldinterface", test_file))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,14 +30,12 @@ if KNITRO.KNITRO_VERSION >= v"11.0"
         include("jump_soc.jl")
     end
     try
-        @testset "License tests" begin
-            @testset "Test C API" begin
-                include("knitroapi_licman.jl")
-            end
+        @testset "Test C API License" begin
+            include("knitroapi_licman.jl")
         end
     catch e
         @warn("License tests failed, but this might be due to License Manager" *
-        " not being supporte by your license.")
+        " not being supported by your license.")
         println("The error catched was:\n")
         println("$e\n")
         println("See table above for more details.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,4 +29,17 @@ if KNITRO.KNITRO_VERSION >= v"11.0"
     @testset "Test JuMP" begin
         include("jump_soc.jl")
     end
+    try
+        @testset "License tests" begin
+            @testset "Test C API" begin
+                include("knitroapi_licman.jl")
+            end
+        end
+    catch e
+        @warn("License tests failed, but this might be due to License Manager" *
+        " not being supporte by your license.")
+        println("The error catched was:\n")
+        println("$e\n")
+        println("See table above for more details.")
+    end
 end


### PR DESCRIPTION
closes #125 

I added "free" as an attribute to be easily accessible via JuMP.

Also added a try catch in the lic manager tests which is not supported by all users.