### PR TITLE
Handle Domain error to trigger Knitro trial iterates

### DIFF
--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -257,6 +257,10 @@ macro wrap_function(wrap_name, name)
             catch ex
                 if isa(ex, InterruptException)
                     return Cint(KN_RC_USER_TERMINATION)
+                end
+                if isa(ex, DomainError)
+                    @warn("Knitro encounters an evaluation error in evaluation callback: $ex")
+                    return Cint(KN_RC_EVAL_ERR)
                 else
                     @warn("Knitro encounters an exception in evaluation callback: $ex")
                     return Cint(KN_RC_CALLBACK_ERR)

--- a/test/knitroapi.jl
+++ b/test/knitroapi.jl
@@ -687,3 +687,22 @@ end
     @test nstatus == KNITRO.KN_RC_CALLBACK_ERR
     KNITRO.KN_free(kc)
 end
+
+@testset "Knitro evaluation exception" begin
+    function eval_kn(kc, cb, evalRequest, evalResult, userParams)
+        x = evalRequest.x
+        evalResult.obj[1] = sqrt(x[1])
+        return 0
+    end
+
+    kc = KNITRO.KN_new()
+    KNITRO.KN_set_param(kc, "outlev", 0)
+    KNITRO.KN_add_vars(kc, 1)
+    # Start from a non-evaluable point
+    KNITRO.KN_set_var_primal_init_values(kc, [-1.0])
+    cb = KNITRO.KN_add_objective_callback(kc, eval_kn)
+    nstatus = KNITRO.KN_solve(kc)
+    nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
+    @test x ≈ [0.] atol=1e-5
+    KNITRO.KN_free(kc)
+end


### PR DESCRIPTION
When an evaluation error was raised in a Knitro callback, the solve was cancelled with error code KN_RC_CALLBACK_ERR.

For example :
┌ Warning: Knitro encounters an exception in evaluation callback: DomainError(-11.06881447546948, "sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).")

Should not necessary stop the solve as Knitro features a system to generate sequence of shorter steps until it generates a trial iterate that is acceptable.

To trigger this system, the callback shall return with error code KN_RC_EVAL_ERR.

Thus, I propose this handling of "DomainError" in Knitro callbacks.