### PR TITLE
Refactor examples to deactivate logs automatically

### DIFF
--- a/examples/conic.jl
+++ b/examples/conic.jl
@@ -24,7 +24,7 @@
 using KNITRO
 
 
-function example_conic()
+function example_conic(; verbose=true)
     #** Create a new Knitro solver instance. */
     kc = KNITRO.KN_new()
 
@@ -104,7 +104,8 @@ function example_conic()
     #** Enable the special barrier tools for second order cone(SOC) constraints. */
     KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_BAR_CONIC_ENABLE, KNITRO.KN_BAR_CONIC_ENABLE_SOC)
     #** Specify maximum output */
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ALL)
+    outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, outlev)
     #** Specify special barrier update rule */
     KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_BAR_MURULE, KNITRO.KN_BAR_MURULE_FULLMPC)
 
@@ -113,22 +114,23 @@ function example_conic()
     ####*  Return status codes are defined in "knitro.h" and described
     ####*  in the Knitro manual. */
     nStatus = KNITRO.KN_solve(kc)
-
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, _ = KNITRO.KN_get_solution(kc)
+    feasError = KNITRO.KN_get_abs_feas_error(kc)
+    optError = KNITRO.KN_get_abs_opt_error(kc)
 
     #** An example of obtaining solution information. */
-    nStatus, objSol, x, _ = KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ", x)
-
-    feasError = KNITRO.KN_get_abs_feas_error(kc)
-    println("  feasibility violation    = ", feasError)
-    optError = KNITRO.KN_get_abs_opt_error(kc)
-    println("  KKT optimality violation = ", optError)
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ", x)
+        println("  feasibility violation    = ", feasError)
+        println("  KKT optimality violation = ", optError)
+    end
 
     #** Delete the Knitro solver instance. */
     KNITRO.KN_free(kc)
 end
 
-example_conic()
+
+example_conic(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/fcga.jl
+++ b/examples/fcga.jl
@@ -23,7 +23,7 @@
 using KNITRO
 using Test
 
-function example_fcga()
+function example_fcga(; verbose=true)
     #*------------------------------------------------------------------*/
     #*     FUNCTION callbackEvalFCGA                                    */
     #*------------------------------------------------------------------*/
@@ -172,7 +172,8 @@ function example_fcga()
     KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MAXIMIZE)
 
     # Set option to print output after every iteration.
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ITER)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Set option to tell Knitro that the gradients are being provided
     # with the functions in one callback.
@@ -183,16 +184,16 @@ function example_fcga()
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 
     # An example of obtaining solution information.
-    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ",   x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
-
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ",   x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -204,5 +205,6 @@ function example_fcga()
     end
 end
 
-example_fcga()
+example_fcga(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
+
 

--- a/examples/lp1.jl
+++ b/examples/lp1.jl
@@ -24,7 +24,7 @@
 using KNITRO
 using Test
 
-function example_lp1()
+function example_lp1(; verbose=true)
     # Create a new Knitro solver instance.
     kc = KNITRO.KN_new()
 
@@ -65,20 +65,23 @@ function example_lp1()
     objCoefs = [-4.0, -2.0]
     KNITRO.KN_add_obj_linear_struct(kc, objIndices, objCoefs)
 
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
+
     # Solve the problem.
     #
     # Return status codes are defined in "kn_defines.jl" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println("Knitro converged with final status = ", nStatus)
-
-    # An example of obtaining solution information.
     nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ",   x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ",   x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -90,5 +93,5 @@ function example_lp1()
     end
 end
 
-example_lp1()
+example_lp1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/lsq1.jl
+++ b/examples/lsq1.jl
@@ -35,7 +35,7 @@
 using KNITRO, Test
 
 
-function example_lsq1()
+function example_lsq1(; verbose=true)
     # Create a new Knitro solver instance.
     kc = KNITRO.KN_new()
 
@@ -83,6 +83,9 @@ function example_lsq1()
     # Pass in the linear coefficients
     KNITRO.KN_add_rsd_linear_struct(kc, indexRsds, indexVars, coefs)
 
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
+
     # Solve the problem.
     #
     # Return status codes are defined in "knitro.h" and described
@@ -97,9 +100,11 @@ function example_lsq1()
         # Return status codes are defined in "knitro.h" and described
         # in the Knitro manual.
         nStatus, obj, x, lambda_ = KNITRO.KN_get_solution(kc)
-        println("Knitro successful. The optimal solution is:")
-        for i in 1:n
-            println("x[$i]=", x[i])
+        if verbose
+            println("Knitro successful. The optimal solution is:")
+            for i in 1:n
+                println("x[$i]=", x[i])
+            end
         end
     end
 
@@ -113,5 +118,5 @@ function example_lsq1()
     end
 end
 
-example_lsq1()
+example_lsq1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/lsq2.jl
+++ b/examples/lsq2.jl
@@ -18,7 +18,7 @@
 using KNITRO
 using Test
 
-function example_lsq2()
+function example_lsq2(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalR                                       *
     #*------------------------------------------------------------------*
@@ -126,6 +126,9 @@ function example_lsq2()
     #(this is true even when using finite-difference gradients).
     KNITRO.KN_set_cb_rsd_jac(kc, cb, KNITRO.KN_DENSE_ROWMAJOR, callbackEvalRJ)
 
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
+
     # Solve the problem.
     #
     # Return status codes are defined in "knitro.h" and described
@@ -137,7 +140,8 @@ function example_lsq2()
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus, obj, x, lambda_ = KNITRO.KN_get_solution(kc)
-    if nStatus != 0
+
+    if nStatus != 0 && verbose
         println("Knitro successful. The optimal solution is:")
         for i in 1:n
             println("x[$i]= ", x[i])
@@ -154,5 +158,5 @@ function example_lsq2()
     end
 end
 
-example_lsq2()
+example_lsq2(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/moi_nlp1.jl
+++ b/examples/moi_nlp1.jl
@@ -62,10 +62,12 @@ function MOI.eval_hessian_lagrangian(d::HS15, H, x, σ, μ)
     return 0
 end
 
-function example_moi_nlp1()
+function example_moi_nlp1(; verbose=true)
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     # Define a Knitro solver instance through MOI.
     solver = KNITRO.Optimizer(outlev=3, opttol=1e-8)
+    MOI.set(solver, MOI.Silent(), !verbose)
+
     lb =[]; ub=[]
     block_data = MOI.NLPBlockData(MOI.NLPBoundsPair.(lb, ub), HS15(false), true)
 
@@ -76,7 +78,7 @@ function example_moi_nlp1()
     start = [-2., 1.]
 
     for i in 1:2
-        MOI.add_constraint(solver, MOI.SingleVariable(v[i]), MOI.LessThan(u[i]))
+        MOI.add_constraint(solver, v[i], MOI.LessThan(u[i]))
         MOI.set(solver, MOI.VariablePrimalStart(), v[i], start[i])
     end
 
@@ -109,5 +111,5 @@ function example_moi_nlp1()
     MOI.empty!(solver)
 end
 
-example_moi_nlp1()
+example_moi_nlp1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/mpec1.jl
+++ b/examples/mpec1.jl
@@ -35,7 +35,7 @@
 
 using KNITRO, Test
 
-function example_mpec1()
+function example_mpec1(; verbose=true)
     # Create a new Knitro solver instance.
     kc = KNITRO.KN_new()
 
@@ -107,23 +107,29 @@ function example_mpec1()
     indexComps2 = Int32[5, 6, 7]
     KNITRO.KN_set_compcons(kc, ccTypes, indexComps1, indexComps2)
 
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
+
     # Solve the problem.
     #
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-    println("Knitro converged with final status = ", nStatus)
 
     # An example of obtaining solution information.
     nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x0=", x[1])
-    println("                        x1=", x[2])
-    println("                        x2=", (x[3], x[6]))
-    println("                        x3=", (x[4], x[7]))
-    println("                        x4=", (x[5], x[8]))
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x0=", x[1])
+        println("                        x1=", x[2])
+        println("                        x2=", (x[3], x[6]))
+        println("                        x3=", (x[4], x[7]))
+        println("                        x4=", (x[5], x[8]))
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -135,5 +141,5 @@ function example_mpec1()
     end
 end
 
-example_mpec1()
+example_mpec1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/multipleCB.jl
+++ b/examples/multipleCB.jl
@@ -24,7 +24,7 @@
 using KNITRO, Test
 
 
-function example_multiple_cb()
+function example_multiple_cb(; verbose=true)
     # The signature of this function matches KNITRO.KN_eval_callback in knitro.h.
     # Only "obj" is set in the KNITRO.KN_eval_result structure.
     function callbackEvalObj(kc, cb, evalRequest, evalResult, userParams)
@@ -201,21 +201,24 @@ function example_multiple_cb()
     # Approximate hessian using BFGS
     KNITRO.KN_set_param(kc, "hessopt", KNITRO.KN_HESSOPT_BFGS)
 
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
+
     # Solve the problem.
     #
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println()
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 
     # An example of obtaining solution information.
-    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ", x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ", x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -227,5 +230,5 @@ function example_multiple_cb()
     end
 end
 
-example_multiple_cb()
+example_multiple_cb(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/nlp1.jl
+++ b/examples/nlp1.jl
@@ -24,7 +24,7 @@
 using KNITRO
 using Test
 
-function example_nlp1()
+function example_nlp1(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalF                                       *
     #*------------------------------------------------------------------*
@@ -92,7 +92,9 @@ function example_nlp1()
     # the knitro.opt file.
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     KNITRO.KN_load_param_file(kc, options)
-    KNITRO.KN_set_param(kc, "outlev", 3)
+
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Initialize Knitro with the problem definition.
 
@@ -178,18 +180,21 @@ function example_nlp1()
 
     # An example of obtaining solution information.
     nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
-    println("Optimal objective value  = ", objSol)
-    println("Optimal x(with corresponding multiplier)")
-    for i in 1:n
-        println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
+
+    if verbose
+        println("Optimal objective value  = ", objSol)
+        println("Optimal x(with corresponding multiplier)")
+        for i in 1:n
+            println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
+        end
+        println("Optimal constraint values(with corresponding multiplier)")
+        c = KNITRO.KN_get_con_values(kc)
+        for j in 1:m
+            println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
+        end
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
     end
-    println("Optimal constraint values(with corresponding multiplier)")
-    c = KNITRO.KN_get_con_values(kc)
-    for j in 1:m
-        println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
-    end
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -201,5 +206,5 @@ function example_nlp1()
     end
 end
 
-example_nlp1()
+example_nlp1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/nlp1_hessian_product.jl
+++ b/examples/nlp1_hessian_product.jl
@@ -24,7 +24,7 @@
 using KNITRO
 using Test
 
-function example_nlp1_hessian_productt()
+function example_nlp1_hessian_product(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalF                                       *
     #*------------------------------------------------------------------*
@@ -95,7 +95,8 @@ function example_nlp1_hessian_productt()
     # the knitro.opt file.
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     KNITRO.KN_load_param_file(kc, options)
-    KNITRO.KN_set_param(kc, "outlev", 3)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Initialize Knitro with the problem definition.
 
@@ -185,18 +186,21 @@ function example_nlp1_hessian_productt()
 
     # An example of obtaining solution information.
     nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
-    println("Optimal objective value  = ", objSol)
-    println("Optimal x(with corresponding multiplier)")
-    for i in 1:n
-        println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
-    end
-    println("Optimal constraint values(with corresponding multiplier)")
     c = KNITRO.KN_get_con_values(kc)
-    for j in 1:m
-        println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
+
+    if verbose
+        println("Optimal objective value  = ", objSol)
+        println("Optimal x(with corresponding multiplier)")
+        for i in 1:n
+            println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
+        end
+        println("Optimal constraint values(with corresponding multiplier)")
+        for j in 1:m
+            println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
+        end
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
     end
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -208,5 +212,5 @@ function example_nlp1_hessian_productt()
     end
 end
 
-example_nlp1_hessian_productt()
+example_nlp1_hessian_product(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/nlp1noderivs.jl
+++ b/examples/nlp1noderivs.jl
@@ -29,7 +29,7 @@
 
 using KNITRO, Test
 
-function example_nlp1noderivs()
+function example_nlp1noderivs(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalF                                       *
     #*------------------------------------------------------------------*
@@ -56,6 +56,8 @@ function example_nlp1noderivs()
     # the knitro.opt file.
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     KNITRO.KN_load_param_file(kc, options)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ALL : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Initialize Knitro with the problem definition.
 
@@ -125,22 +127,23 @@ function example_nlp1noderivs()
 
     # An example of obtaining solution information.
     nStatus, objSol, x, lambda_ = KNITRO.KN_get_solution(kc)
-    println("Optimal objective value  = ", objSol)
-    println("Optimal x(with corresponding multiplier)")
-    for i in 1:n
-        println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
+    if verbose
+        println("Optimal objective value  = ", objSol)
+        println("Optimal x(with corresponding multiplier)")
+        for i in 1:n
+            println("  x[$i] = ", x[i], "(lambda = ",  lambda_[m+i], ")")
+        end
+        println("Optimal constraint values(with corresponding multiplier)")
+        c = KNITRO.KN_get_con_values(kc)
+        for j in 1:m
+            println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
+        end
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
     end
-    println("Optimal constraint values(with corresponding multiplier)")
-    c = KNITRO.KN_get_con_values(kc)
-    for j in 1:m
-        println("  c[$j] = ", c[j], "(lambda = ",  lambda_[j], ")")
-    end
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
-
 
     @testset "Example HS15 nlp1noderivs" begin
         @test nStatus == 0
@@ -149,5 +152,5 @@ function example_nlp1noderivs()
     end
 end
 
-example_nlp1noderivs()
+example_nlp1noderivs(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/nlp2.jl
+++ b/examples/nlp2.jl
@@ -23,7 +23,7 @@
 
 using KNITRO, Test
 
-function example_nlp2()
+function example_nlp2(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalFC                                      *
     #*------------------------------------------------------------------*
@@ -114,12 +114,15 @@ function example_nlp2()
         # Get the number of variables in the model
         n = KNITRO.KN_get_number_vars(kc)
 
-        println(">> New point computed by Knitro:(", x, ")")
 
         # Query information about the current problem.
         dFeasError = KNITRO.KN_get_abs_feas_error(kc)
-        println("Number FC evals= ", KNITRO.KN_get_number_FC_evals(kc))
-        println("Current feasError= " , dFeasError)
+
+        if verbose
+            println(">> New point computed by Knitro:(", x, ")")
+            println("Number FC evals= ", KNITRO.KN_get_number_FC_evals(kc))
+            println("Current feasError= " , dFeasError)
+        end
 
         # Demonstrate user-defined termination
         #(Uncomment to activate)
@@ -205,23 +208,25 @@ function example_nlp2()
     KNITRO.KN_set_newpt_callback(kc, callbackNewPoint)
 
     # Set option to println output after every iteration.
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ITER)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Solve the problem.
     #
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println()
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 
     # An example of obtaining solution information.
-    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ", x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    if verbose
+        println()
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ", x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -233,5 +238,5 @@ function example_nlp2()
     end
 end
 
-example_nlp2()
+example_nlp2(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/nlp2noderivs.jl
+++ b/examples/nlp2noderivs.jl
@@ -19,7 +19,7 @@
 
 using KNITRO, Test
 
-function example_nlp2noderivs()
+function example_nlp2noderivs(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalFC                                      *
     #*------------------------------------------------------------------*
@@ -88,7 +88,8 @@ function example_nlp2noderivs()
     KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MAXIMIZE)
 
     # Set option to println output after every iteration.
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ITER)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Solve the problem.
     #
@@ -130,7 +131,8 @@ function example_nlp2noderivs()
 end
 
 if KNITRO.KNITRO_VERSION >= v"12.4"
-    example_nlp2noderivs()
+    example_nlp2noderivs(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 else
-    println("This example is only available with Knitro >= 12.4")
+    println("Example `nlp2noderivs.jl` is only available with Knitro >= 12.4")
 end
+

--- a/examples/nlp2resolve.jl
+++ b/examples/nlp2resolve.jl
@@ -37,7 +37,7 @@
 
 using KNITRO, Test
 
-function example_nlp2resolve()
+function example_nlp2resolve(; verbose=true)
     #*------------------------------------------------------------------*
     #*     FUNCTION callbackEvalFC                                      *
     #*------------------------------------------------------------------*
@@ -182,7 +182,8 @@ function example_nlp2resolve()
     KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MAXIMIZE)
 
     # Set option to println output after every iteration.
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ITER)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Solve the initial problem.
     #
@@ -250,7 +251,8 @@ function example_nlp2resolve()
 end
 
 if KNITRO.KNITRO_VERSION >= v"12.4"
-    example_nlp2resolve()
+    example_nlp2resolve(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 else
-    println("This example is only available with Knitro >= 12.4")
+    println("Example `nlp2resolve.jl` is only available with Knitro >= 12.4")
 end
+

--- a/examples/qcqp1.jl
+++ b/examples/qcqp1.jl
@@ -22,7 +22,7 @@
 using KNITRO
 using Test
 
-function example_qcqp1()
+function example_qcqp1(; verbose=true)
     # Create a new Knitro solver instance.
     kc = KNITRO.KN_new()
 
@@ -30,6 +30,8 @@ function example_qcqp1()
     # the knitro.opt file.
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     KNITRO.KN_load_param_file(kc, options)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Initialize Knitro with the problem definition.
 
@@ -73,16 +75,16 @@ function example_qcqp1()
     # Return status codes are defined in "knitro.h" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println()
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 
     # An example of obtaining solution information.
-    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ", x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ", x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
 
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
@@ -94,5 +96,5 @@ function example_qcqp1()
     end
 end
 
-example_qcqp1()
+example_qcqp1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/qp1.jl
+++ b/examples/qp1.jl
@@ -25,7 +25,7 @@
 using KNITRO
 using Test
 
-function example_qp1()
+function example_qp1(; verbose=true)
     # Used to specify whether linear and quadratic objective
     # terms are loaded separately or together in this example.
     bSeparate = false
@@ -37,6 +37,8 @@ function example_qp1()
     # the knitro.opt file.
     options = joinpath(dirname(@__FILE__), "..", "examples", "knitro.opt")
     KNITRO.KN_load_param_file(kc, options)
+    kn_outlev = verbose ? KNITRO.KN_OUTLEV_ITER : KNITRO.KN_OUTLEV_NONE
+    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, kn_outlev)
 
     # Initialize Knitro with the problem definition.
 
@@ -82,7 +84,6 @@ function example_qp1()
 
     # Enable iteration output and crossover procedure to try to
     # get more solution precision
-    KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_OUTLEV, KNITRO.KN_OUTLEV_ITER)
     KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_BAR_MAXCROSSIT, 5)
 
     # Solve the problem.
@@ -90,15 +91,16 @@ function example_qp1()
     # Return status codes are defined in "kn_defines.jl" and described
     # in the Knitro manual.
     nStatus = KNITRO.KN_solve(kc)
-
-    println("Knitro converged with final status = ", nStatus)
+    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
 
     # An example of obtaining solution information.
-    nStatus, objSol, x, lambda_ =  KNITRO.KN_get_solution(kc)
-    println("  optimal objective value  = ", objSol)
-    println("  optimal primal values x  = ",  x)
-    println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
-    println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    if verbose
+        println("Knitro converged with final status = ", nStatus)
+        println("  optimal objective value  = ", objSol)
+        println("  optimal primal values x  = ",  x)
+        println("  feasibility violation    = ", KNITRO.KN_get_abs_feas_error(kc))
+        println("  KKT optimality violation = ", KNITRO.KN_get_abs_opt_error(kc))
+    end
     # Delete the Knitro solver instance.
     KNITRO.KN_free(kc)
 
@@ -109,5 +111,5 @@ function example_qp1()
     end
 end
 
-example_qp1()
+example_qp1(; verbose=isdefined(Main, :KN_VERBOSE) ? KN_VERBOSE : true)
 

--- a/examples/tuner-fixed.opt
+++ b/examples/tuner-fixed.opt
@@ -1,5 +1,4 @@
-# This file is used to specify any non-default options that will 
+# This file is used to specify any non-default options that will
 # be fixed by the Knitro-Tuner.
 
 algorithm          direct
-tuner_maxtime_real 3600

--- a/src/kn_callbacks.jl
+++ b/src/kn_callbacks.jl
@@ -259,7 +259,6 @@ macro wrap_function(wrap_name, name)
                     return Cint(KN_RC_USER_TERMINATION)
                 end
                 if isa(ex, DomainError)
-                    @warn("Knitro encounters an evaluation error in evaluation callback: $ex")
                     return Cint(KN_RC_EVAL_ERR)
                 else
                     @warn("Knitro encounters an exception in evaluation callback: $ex")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using KNITRO
 using Test
 
+const KN_VERBOSE = false
+
 @testset "Test C API" begin
     include("knitroapi.jl")
 end


### PR DESCRIPTION
- Fixed remaining MOI.SingleVariable in `examples/moi_nlp1.jl`
- Remove warning issued when DomainError is encountered in callbacks (over-flood logs)
- Remove deprecated option in tuner file (solve #175 )