### PR TITLE
Change behavior of Knitro.jl when shared lib is not detected

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -42,9 +42,7 @@ for path in reverse(paths_to_try)
     end
 end
 
-if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
-    write_depsfile("", "julia_registryci_automerge")
-elseif !found_knitro
-    error("Unable to locate KNITRO installation, " *
-          "please check your environment variable KNITRODIR.")
+if !found_knitro
+    write_depsfile("", "")
 end
+

--- a/src/KNITRO.jl
+++ b/src/KNITRO.jl
@@ -10,23 +10,28 @@ end
 using Libdl, SparseArrays
 import Base: show
 
-const KNITRO_VERSION = if libknitro == "julia_registryci_automerge"
-    VersionNumber(11, 0, 0) # Fake a valid version for AutoMerge
-else
+const IS_KNITRO_LOADED = endswith(libknitro, Libdl.dlext)
+
+const KNITRO_VERSION = if IS_KNITRO_LOADED
     len = 15
     out = zeros(Cchar, len)
     ccall((:KTR_get_release, libknitro), Any, (Cint, Ptr{Cchar}), len, out)
     res = String(strip(String(convert(Vector{UInt8}, out)), '\0'))
     VersionNumber(split(res, " ")[2])
+else
+    VersionNumber(0, 0, 0) # Fake a version for AutoMerge
 end
 
-if KNITRO_VERSION < v"11.0"
+if KNITRO_VERSION != v"0.0.0" && KNITRO_VERSION < v"11.0"
     error(
         "You have installed version $KNITRO_VERSION of Artelys Knitro, which is not supported
   by KNITRO.jl. We require a Knitro version greater than 11.0.
   ",
     )
 end
+
+has_knitro() = IS_KNITRO_LOADED
+knitro_version() = KNITRO_VERSION
 
 include("libknitro.jl")
 include("C_wrapper.jl")


### PR DESCRIPTION
KNITRO.jl does not raise an error anymore when no shared library has been detected:

```julia
using KNITRO
KNITRO.has_knitro() # return true if shared library found

```
The user is now in charge of making sure that KNITRO.jl is build correctly. Solve #205 