### PR TITLE
Expose the nnzJ argument in KN_set_cb_grad.

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -332,7 +332,7 @@ function KN_set_cb_grad(
     cb::CallbackContext,
     gradcallback;
     nV::Integer=KN_DENSE,
-    nnzJ::Integer=KNLONG(0),
+    nnzJ::Integer=(iszero(KNITRO.KN_get_number_cons(m)) ? KNLONG(0) : KNITRO.KN_DENSE_COLMAJOR),
     objGradIndexVars=C_NULL,
     jacIndexCons=C_NULL,
     jacIndexVars=C_NULL,

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -332,6 +332,7 @@ function KN_set_cb_grad(
     cb::CallbackContext,
     gradcallback;
     nV::Integer=KN_DENSE,
+    nnzJ::Integer=KNLONG(0),
     objGradIndexVars=C_NULL,
     jacIndexCons=C_NULL,
     jacIndexVars=C_NULL,
@@ -344,7 +345,6 @@ function KN_set_cb_grad(
         @assert (objGradIndexVars != C_NULL) && (length(objGradIndexVars) == nV)
     end
 
-    nnzJ = KNLONG(0)
     if jacIndexCons != C_NULL && jacIndexVars != C_NULL
         @assert length(jacIndexCons) == length(jacIndexVars)
         nnzJ = KNLONG(length(jacIndexCons))
@@ -372,7 +372,7 @@ function KN_set_cb_grad(
         cb,
         nV,
         objGradIndexVars,
-        nnzJ,
+        KNLONG(nnzJ),
         jacIndexCons,
         jacIndexVars,
         c_grad_g


### PR DESCRIPTION
Exposing the `nnzJ` argument in `KN_set_cb_grad`. It was set to `KNLONG(0)` manually inside the function in the current version so I made that the default value, and instead of adding the type constraint `nnzJ::KNLONG` I just force it to be `::Integer` and then add a safety conversion in the actual library call at the end of the function. Please let me know if some other method is preferable.