### PR TITLE
Remove support for ConstraintDual of SecondOrderCone

### DIFF
--- a/src/MOI_wrapper/results.jl
+++ b/src/MOI_wrapper/results.jl
@@ -184,15 +184,13 @@ function MOI.get(
     return g[model.constraint_mapping[ci].+1]
 end
 
-function MOI.get(
-    model::Optimizer,
-    cp::MOI.ConstraintPrimal,
-    ci::MOI.ConstraintIndex{S,MOI.SecondOrderCone},
-) where {S<:Union{MOI.VectorAffineFunction{Float64},MOI.VectorOfVariables}}
-    checkcons(model, ci, cp)
-    x = get_solution(model.inner)
-    return x[model.constraint_mapping[ci].+1]
-end
+# function MOI.get(
+#     model::Optimizer,
+#     cp::MOI.ConstraintPrimal,
+#     ci::MOI.ConstraintIndex{S,MOI.SecondOrderCone},
+# ) where {S<:Union{MOI.VectorAffineFunction{Float64},MOI.VectorOfVariables}}
+#     return # Not supported
+# end
 
 function MOI.get(
     model::Optimizer,
@@ -253,31 +251,13 @@ function MOI.get(
     return sense_dual(model) * lambda[index]
 end
 
-# Get constraint of a SOC constraint.
-#
-# Use the following mathematical property.  Let
-#
-#   ||u_i || <= t_i      with dual constraint    || z_i || <= w_i
-#
-# At optimality, we have
-#
-#   w_i * u_i  = - t_i z_i
-function MOI.get(
-    model::Optimizer,
-    cd::MOI.ConstraintDual,
-    ci::MOI.ConstraintIndex{S,T},
-) where {
-    S<:Union{MOI.VectorAffineFunction{Float64},MOI.VectorOfVariables},
-    T<:MOI.SecondOrderCone,
-}
-    checkcons(model, ci, cd)
-    index_var = model.constraint_mapping[ci] .+ 1
-    index_con = ci.value + 1
-    x = get_solution(model.inner)[index_var]
-    t_i, u_i = x[1], x[2:end]
-    w_i = get_dual(model.inner)[index_con]
-    return [-w_i; 1 / t_i * w_i * u_i]
-end
+# function MOI.get(
+#     model::Optimizer,
+#     cd::MOI.ConstraintDual,
+#     ci::MOI.ConstraintIndex{S,MOI.SecondOrderCone},
+# ) where {S<:Union{MOI.VectorAffineFunction{Float64},MOI.VectorOfVariables}}
+#     return  # Not supported.
+# end
 
 function _reduced_cost(
     model,

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -22,6 +22,22 @@ function runtests()
 end
 
 function test_MOI_Test_cached()
+    second_order_exclude = String[
+        "test_conic_GeometricMeanCone_VectorAffineFunction",
+        "test_conic_GeometricMeanCone_VectorAffineFunction_2",
+        "test_conic_GeometricMeanCone_VectorOfVariables",
+        "test_conic_GeometricMeanCone_VectorOfVariables_2",
+        "test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
+        "test_conic_RotatedSecondOrderCone_VectorAffineFunction",
+        "test_conic_RotatedSecondOrderCone_VectorOfVariables",
+        "test_conic_RotatedSecondOrderCone_out_of_order",
+        "test_conic_SecondOrderCone_Nonpositives",
+        "test_conic_SecondOrderCone_Nonnegatives",
+        "test_conic_SecondOrderCone_VectorAffineFunction",
+        "test_conic_SecondOrderCone_VectorOfVariables",
+        "test_conic_SecondOrderCone_out_of_order",
+        "test_constraint_PrimalStart_DualStart_SecondOrderCone",
+    ]
     model = MOI.Utilities.CachingOptimizer(
         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
         MOI.instantiate(KNITRO.Optimizer; with_bridge_type=Float64),
@@ -41,22 +57,6 @@ function test_MOI_Test_cached()
             ],
         );
         exclude=String[
-            # TODO(odow): investigate SecondOrderCone-related failures
-            # x-ref: https://github.com/jump-dev/KNITRO.jl/issues/201
-            "test_conic_GeometricMeanCone_VectorAffineFunction",
-            "test_conic_GeometricMeanCone_VectorAffineFunction_2",
-            "test_conic_GeometricMeanCone_VectorOfVariables",
-            "test_conic_GeometricMeanCone_VectorOfVariables_2",
-            "test_conic_RotatedSecondOrderCone_INFEASIBLE_2",
-            "test_conic_RotatedSecondOrderCone_VectorAffineFunction",
-            "test_conic_RotatedSecondOrderCone_VectorOfVariables",
-            "test_conic_RotatedSecondOrderCone_out_of_order",
-            "test_conic_SecondOrderCone_Nonpositives",
-            "test_conic_SecondOrderCone_Nonnegatives",
-            "test_conic_SecondOrderCone_VectorAffineFunction",
-            "test_conic_SecondOrderCone_VectorOfVariables",
-            "test_conic_SecondOrderCone_out_of_order",
-            "test_constraint_PrimalStart_DualStart_SecondOrderCone",
             # Returns OTHER_ERROR, which is also reasonable.
             "test_conic_empty_matrix",
             # Uses the ZerosBridge and ConstraintDual
@@ -67,7 +67,24 @@ function test_MOI_Test_cached()
             "test_solve_ObjectiveBound_MAX_SENSE_LP",
             # KNITRO doesn't support INFEASIBILITY_CERTIFICATE results.
             "test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_",
+            second_order_exclude...,
         ],
+    )
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(
+            atol=1e-3,
+            rtol=1e-3,
+            optimal_status=MOI.LOCALLY_SOLVED,
+            infeasible_status=MOI.LOCALLY_INFEASIBLE,
+            exclude=Any[
+                MOI.ConstraintBasisStatus,
+                MOI.VariableBasisStatus,
+                MOI.DualObjectiveValue,
+                MOI.ConstraintDual,
+            ],
+        );
+        include=second_order_exclude,
     )
     return
 end


### PR DESCRIPTION
ConstraintPrimal and ConstraintDual for SecondOrderCone were just wrong, so we should remove them.

Now ConstraintPrimal goes through a fallback, so we're left with needing to exclude the ConstraintDual of some SecondOrderCone tests.

x-ref: #233 