### PR TITLE
Update some tests for KNITRO 14

### DIFF
--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -111,7 +111,7 @@ if KNITRO.knitro_version() >= v"12.1"
         KN_get_solution(kc, Ref{Cint}(), obj, C_NULL, C_NULL)
         KN_free(kc)
         @test status == 0
-        @test obj[] ≈ 250.0 / 3.0
+        @test isapprox(obj[], 250.0 / 3.0, rtol=1e-6)
 
         # Resolve with dumped MPS file
         kc = KN_new()
@@ -122,7 +122,7 @@ if KNITRO.knitro_version() >= v"12.1"
         KN_get_solution(kc, Ref{Cint}(), obj, C_NULL, C_NULL)
         KN_free(kc)
         @test status == 0
-        @test obj[] ≈ 250.0 / 3.0
+        @test isapprox(obj[], 250.0 / 3.0, rtol=1e-6)
     end
 end
 


### PR DESCRIPTION
Superseded #287.
It could help for #284.
```julia
     Testing Running tests...
[KNITRO.jl] 
[KNITRO.jl] =======================================
[KNITRO.jl]             Student License
       (NOT FOR COMMERCIAL USE)
[KNITRO.jl]          Artelys Knitro 14.0.0
[KNITRO.jl] =======================================
[KNITRO.jl] 
[KNITRO.jl] hessopt:                 5
[KNITRO.jl] hessian_no_f:            1
[KNITRO.jl] ms_enable:               1
[KNITRO.jl] ms_maxsolves:            5
[KNITRO.jl] ms_numthreads:           1
[KNITRO.jl] numthreads:              1
[KNITRO.jl] presolve:                0
[KNITRO.jl] The problem is identified as an MPEC.
[KNITRO.jl] 
[KNITRO.jl] Problem Characteristics
[KNITRO.jl] -----------------------
[KNITRO.jl] Objective goal:  Maximize
[KNITRO.jl] Objective type:  general
[KNITRO.jl] Number of variables:                                  3
[KNITRO.jl]     bounded below only:                               0
[KNITRO.jl]     bounded above only:                               0
[KNITRO.jl]     bounded below and above:                          2
[KNITRO.jl]     fixed:                                            1
[KNITRO.jl]     free:                                             0
[KNITRO.jl] Number of constraints:                                1
[KNITRO.jl]     linear equalities:                                0
[KNITRO.jl]     quadratic equalities:                             0
[KNITRO.jl]     gen. nonlinear equalities:                        0
[KNITRO.jl]     linear one-sided inequalities:                    0
[KNITRO.jl]     quadratic one-sided inequalities:                 0
[KNITRO.jl]     gen. nonlinear one-sided inequalities:            0
[KNITRO.jl]     linear two-sided inequalities:                    0
[KNITRO.jl]     quadratic two-sided inequalities:                 1
[KNITRO.jl]     gen. nonlinear two-sided inequalities:            0
[KNITRO.jl] Number of complementarities:                          1
[KNITRO.jl] Number of nonzeros in Jacobian:                       2
[KNITRO.jl] Number of nonzeros in Hessian:                        0
[KNITRO.jl] 
Multistart will generate 5 start points as follows:
[KNITRO.jl]       3 variables will vary within their upper and lower bounds
[KNITRO.jl]       0 variables will vary over a range of 1000
[KNITRO.jl] 
Knitro multistart will run with 1 thread.

[KNITRO.jl]  Solve #  ThreadID  Status     Objective     FeasError   OptError   Real Time 
[KNITRO.jl] --------  --------  ------  --------------  ----------  ---------- ----------
[KNITRO.jl]        1         0       0    3.136280e+01   0.000e+00   1.297e-05      0.001
ms callback
[KNITRO.jl]        2         0       0    3.136319e+01   0.000e+00   2.230e-07      0.001
ms callback
[KNITRO.jl]        3         0       0    3.136315e+01   0.000e+00   2.578e-06      0.000
ms callback
[KNITRO.jl]        4         0       0    3.136280e+01   0.000e+00   1.297e-05      0.000
ms callback
[KNITRO.jl]        5         0       0    3.136280e+01   0.000e+00   1.287e-05      0.011
ms callback
[KNITRO.jl] Multistart stopping, reached ms_maxsolves limit.
[KNITRO.jl] 
[KNITRO.jl] MULTISTART: Best locally optimal solution is returned.
[KNITRO.jl] EXIT: Locally optimal solution found.
[KNITRO.jl] 
[KNITRO.jl] Final Statistics
[KNITRO.jl] ----------------
[KNITRO.jl] Final objective value               =   3.13631941097270e+01
[KNITRO.jl] Final feasibility error (abs / rel) =   0.00e+00 / 0.00e+00
[KNITRO.jl] Final optimality error  (abs / rel) =   2.23e-07 / 4.74e-09
[KNITRO.jl] # of iterations                     =         28 
[KNITRO.jl] # of CG iterations                  =         44 
[KNITRO.jl] # of function evaluations           =         43
[KNITRO.jl] # of gradient evaluations           =         33
[KNITRO.jl] # of Hessian-vector product evals   =        122
[KNITRO.jl] Total program time (secs)           =       0.12562 (     0.064 CPU time)
[KNITRO.jl] 
[KNITRO.jl] ===============================================================================
[KNITRO.jl] 
mip_node
mip_node
mip_node
mip_node
mip_node
mip_node
mip_node
┌ Warning: Knitro encounters an exception in puts callback: LoadError
└ @ KNITRO ~/Bureau/git/KNITRO.jl/src/C_wrapper.jl:271
┌ Warning: Knitro encounters an exception in puts callback: LoadError
└ @ KNITRO ~/Bureau/git/KNITRO.jl/src/C_wrapper.jl:271
┌ Warning: Knitro encounters an exception in puts callback: LoadError
└ @ KNITRO ~/Bureau/git/KNITRO.jl/src/C_wrapper.jl:271
Test Summary: | Pass  Total  Time
Test C API    |   86     86  8.4s
[ Info: Executing conic.jl
[ Info: Executing fcga.jl
[ Info: Executing lp1.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing lsq1.jl
[ Info: Executing lsq2.jl
[ Info: Executing minlp1.jl
[ Info: Executing moi_nlp1.jl
[ Info: Executing mpec1.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing multipleCB.jl
[ Info: Executing multistart.jl
Force Knitro multistart to run in parallel with 1 threads (instead of 4).
[ Info: Executing nlp1.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing nlp1_hessian_product.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing nlp1noderivs.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing nlp2.jl
[ Info: Executing nlp2noderivs.jl
[ Info: Executing nlp2resolve.jl
[ Info: Executing qcqp1.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing qp1.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing restart.jl
KTR_load_param_file detects syntax error for 'mip_knapsack', line 458
ERROR: Knitro option 'mip_knapsack', was not set correctly.
       This option will be ignored if the optimization continues.
[ Info: Executing tuner.jl
Force Knitro multistart to run in parallel with 1 threads (instead of 4).
Test Summary: | Pass  Total   Time
Test examples |   52     52  17.0s
┌ Warning: The exclude string "test_linear_DUAL_INFEASIBLE" is ambiguous because it exactly matches a test, but it also partially matches another. Use `r"^test_linear_DUAL_INFEASIBLE$"` to exclude the exactly matching test, or `r"test_linear_DUAL_INFEASIBLE.*"` to exclude all partially matching tests.
└ @ MathOptInterface.Test ~/.julia/packages/MathOptInterface/nEHaN/src/Test/Test.jl:239
┌ Warning: The exclude string "test_conic_GeometricMeanCone_VectorAffineFunction" is ambiguous because it exactly matches a test, but it also partially matches another. Use `r"^test_conic_GeometricMeanCone_VectorAffineFunction$"` to exclude the exactly matching test, or `r"test_conic_GeometricMeanCone_VectorAffineFunction.*"` to exclude all partially matching tests.
└ @ MathOptInterface.Test ~/.julia/packages/MathOptInterface/nEHaN/src/Test/Test.jl:239
┌ Warning: The exclude string "test_conic_GeometricMeanCone_VectorOfVariables" is ambiguous because it exactly matches a test, but it also partially matches another. Use `r"^test_conic_GeometricMeanCone_VectorOfVariables$"` to exclude the exactly matching test, or `r"test_conic_GeometricMeanCone_VectorOfVariables.*"` to exclude all partially matching tests.
└ @ MathOptInterface.Test ~/.julia/packages/MathOptInterface/nEHaN/src/Test/Test.jl:239

test_constraint_ZeroOne_bounds_3: Error During Test at /home/alexis/.julia/packages/MathOptInterface/nEHaN/src/Test/Test.jl:266
  Got exception outside of a @test
  StackOverflowError:
```